### PR TITLE
implementing the socialite providers AbstractProvider and User classes

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -2,9 +2,9 @@
 
 namespace SocialiteProviders\Slack;
 
-use Laravel\Socialite\Two\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use Laravel\Socialite\Two\ProviderInterface;
-use Laravel\Socialite\Two\User;
+use SocialiteProviders\Manager\OAuth2\User;
 
 class Provider extends AbstractProvider implements ProviderInterface
 {


### PR DESCRIPTION
Issue https://github.com/SocialiteProviders/Slack/issues/3, simple fix for getting slack _incoming webhook_ like so: 

``` php
Socialite::driver('slack')->user()->accessTokenResponseBody['incoming_webhook']; 
```
